### PR TITLE
x13path function to be imported by other pkg

### DIFF
--- a/R/x13path.R
+++ b/R/x13path.R
@@ -1,0 +1,3 @@
+x13path <- function(){
+  system.file("bin", package="x13binary")
+}

--- a/tests/simpleTest.R
+++ b/tests/simpleTest.R
@@ -1,3 +1,5 @@
+x13binary::checkX13binary()
+
 
 library(x13binary)
 


### PR DESCRIPTION
So I would only import this function, and will not use `checkX13binary()` in seasonal. 
