### PR TITLE
Add setInternet2() to Windows download

### DIFF
--- a/configure.win
+++ b/configure.win
@@ -5,7 +5,7 @@ R_SCRIPT="${R_HOME}/bin${R_ARCH_BIN}/Rscript"
 cwd=$(pwd)
 
 cd inst
-"${R_SCRIPT}" -e "download.file('https://github.com/x13org/x13prebuilt/raw/master/windows/x13ashtml.zip', 'x13ashtml.zip', quiet = TRUE, mode = \"wb\")"
+"${R_SCRIPT}" -e "setInternet2(); download.file('https://github.com/x13org/x13prebuilt/raw/master/windows/x13ashtml.zip', 'x13ashtml.zip', quiet = TRUE, mode = \"wb\")"
 unzip -u x13ashtml.zip
 cp x13ashtml/x13ashtml.exe bin
 rm x13ashtml.zip


### PR DESCRIPTION
This is needed on older versions of R but does not hurt on most recent (for download.file()). Tested on 3.2.3, 3.2.1, 3.1.2, 2.15.3
