### PR TITLE
added supportedPlatform

### DIFF
--- a/R/supportedPlatform.R
+++ b/R/supportedPlatform.R
@@ -1,0 +1,41 @@
+supportedPlatform <- function(){
+
+  z <- FALSE  # in case we missed something
+
+  # Windows
+  if (.Platform$OS.type == "windows"){
+    z <- TRUE
+  }
+
+  # Linux
+  if (Sys.info()["sysname"] %in% c("Linux")){
+    z <- TRUE
+  }
+
+  # OS-X
+  if (Sys.info()["sysname"] %in% c("Darwin")){
+    # Darwin Version numbers for OS-X Versions 
+    # https://en.wikipedia.org/wiki/Darwin_(operating_system)
+    #     10  OS X Snow Leopard
+    # 11.0.0  OS X Lion
+    # 12.0.0  OS X Mountain Lion
+    # 12.6.0  
+    # 13.0.0  OS X Mavericks
+    # 13.4.0  
+    # 14.0.0  OS X Yosemite
+    # 14.5.0  
+    # 15.0.0  OS X El Capitan
+    # 15.2.0  
+
+    # OS-X needs to be at least Lion (TODO try out)
+    z <- compareVersion(Sys.info()["release"], "11.0.0") >= 0
+  }
+
+  # Other Unix (eg Solaris)
+  if ((.Platform$OS.type == "unix") && 
+      !(Sys.info()["sysname"] %in% c("Darwin", "Linux"))){
+    z <- FALSE
+  }
+
+  z
+}


### PR DESCRIPTION
put the checks if the platform is supported to a separate function, `supportedPlatform`, in x13binary. Returns TRUE if the platform is supported, FALSE otherwise (on Solaris and OS-X <= Snow Leopard).
- seasonal needs to know if the platform is supported at several points: It only asks to remove X13_PATH if the platform is supported. It still asks to set the X13_PATH if the platform is unsupported.
- this function should be part of x13binary. If we add additional support for a platform, we only need to update x13binary, not seasonal.
- `checkX13binary` relies `supportedPlatform` and does not need to be modified if support is extended.
