### PR TITLE
Feature/build26

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: x13binary
 Type: Package
 Title: Provide the 'x13ashtml' Seasonal Adjustment Binary
-Version: 0.1.1
-Date: 2016-02-10
+Version: 0.1.1.1
+Date: 2016-03-09
 Author: Dirk Eddelbuettel and Christoph Sax
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: The US Census provides a seasonal adjustment program now

--- a/configure
+++ b/configure
@@ -72,13 +72,13 @@ cwd=$(pwd)
 ## On Linux, download binary
 if [ ${platform} == "linux" ]; then
     cd inst/bin
-    download https://github.com/x13org/x13prebuilt/raw/master/linux/${flavour}/x13ashtml
+    download https://github.com/x13org/x13prebuilt/raw/master/v1.1.26/linux/${flavour}/x13ashtml
     chmod 0775 x13ashtml
     echo "*** downloaded Linux binary"
     cd ${cwd}
 elif [ ${platform} == "osx" ]; then
     cd inst
-    download https://github.com/x13org/x13prebuilt/raw/master/osx/x13ashtml.tar.gz
+    download https://github.com/x13org/x13prebuilt/raw/master/v1.1.26/osx/x13ashtml.tar.gz
     tar -zxvf x13ashtml.tar.gz
     cp -r x13ashtml/bin .
     cp -r x13ashtml/lib .

--- a/configure.win
+++ b/configure.win
@@ -5,7 +5,7 @@ cd inst
 r_script="${R_HOME}/bin${R_ARCH_BIN}/Rscript"
 set_internet2=`"${r_script}" -e "cat(ifelse(compareVersion(paste(R.Version()['major'], R.Version()['minor'], sep = '.'), '3.2.2') > 0, '', 'setInternet2();'))"`
 
-"${r_script}" -e "${set_internet2} download.file('https://github.com/x13org/x13prebuilt/raw/master/windows/x13ashtml.zip', 'x13ashtml.zip', quiet = TRUE, mode = \"wb\")"
+"${r_script}" -e "${set_internet2} download.file('https://github.com/x13org/x13prebuilt/raw/master/v1.1.26/windows/x13ashtml.zip', 'x13ashtml.zip', quiet = TRUE, mode = \"wb\")"
 unzip -u x13ashtml.zip
 cp x13ashtml/x13ashtml.exe bin
 rm x13ashtml.zip


### PR DESCRIPTION
Installs on Win (appveyor), Linux (travis) and Mac (my box). 

On the mac, I get the numerically identical results  for about 100 test runs as with build19, so everything seems to be fine. 
