### PR TITLE
Branch by sub-arch

### DIFF
--- a/configure
+++ b/configure
@@ -39,7 +39,7 @@ if [ ${sysname} = "Linux" ]; then
     elif [ "${arch}" = "armv7l" ]; then
         flavour="armv7l"
     else
-        echo "Unknown architecture: ${arch}. Exiting."
+        echo "Unknown Linux architecture: ${arch}. Exiting."
         exit 2
     fi
 elif [ ${sysname} = "Darwin" ]; then
@@ -50,7 +50,7 @@ elif [ ${sysname} = "Darwin" ]; then
     elif [ "${arch}" = "arm64" ]; then
         flavour="arm64"
     else
-        echo "Unknown architecture: ${arch}. Exiting."
+        echo "Unknown Darwin (macOS) architecture: ${arch}. Exiting."
         exit 2
     fi
 else

--- a/configure
+++ b/configure
@@ -44,6 +44,15 @@ if [ ${sysname} = "Linux" ]; then
     fi
 elif [ ${sysname} = "Darwin" ]; then
     platform="mac"
+    arch=`uname -m`
+    if [ "${arch}" = "x86_64" ]; then
+        flavour="64"
+    elif [ "${arch}" = "arm64" ]; then
+        flavour="arm64"
+    else
+        echo "Unknown architecture: ${arch}. Exiting."
+        exit 2
+    fi
 else
     platform=${sysname}
     echo "Unusual platform: ${sysname}"
@@ -80,7 +89,7 @@ if [ ${platform} = "linux" ]; then
     cd ${cwd}
 elif [ ${platform} = "mac" ]; then
     cd inst
-    download https://github.com/x13org/x13prebuilt/raw/master/v1.1.57/mac/x13ashtml.tar.gz
+    download https://github.com/x13org/x13prebuilt/raw/master/v1.1.57/mac/${flavour}/x13ashtml.tar.gz
     tar -zxvf x13ashtml.tar.gz
     cp -r x13ashtml/bin .
     cp -r x13ashtml/lib .


### PR DESCRIPTION
Needs https://github.com/x13org/x13prebuilt/pull/16.

After that, I see (with local tweaks):

``` r
x13binary::checkX13binary()
#> x13binary is working properly
```

<sup>Created on 2021-08-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0.9000)</sup>