### PR TITLE
Fail hard and loud

### DIFF
--- a/configure
+++ b/configure
@@ -20,7 +20,7 @@
 ##  You should have received a copy of the GNU General Public License
 ##  along with x13binary.  If not, see <http://www.gnu.org/licenses/>.
 
-set -eo pipefail
+set -e
 
 ## Check that we are on Unix
 if ! [ -x `command -v uname` ]; then

--- a/configure
+++ b/configure
@@ -20,6 +20,8 @@
 ##  You should have received a copy of the GNU General Public License
 ##  along with x13binary.  If not, see <http://www.gnu.org/licenses/>.
 
+set -eo pipefail
+
 ## Check that we are on Unix
 if ! [ -x `command -v uname` ]; then
     echo "You do not have 'uname' so this is unlikely to be a Unix system. Exiting."


### PR DESCRIPTION
in default `./configure` script.