### PR TITLE
make the temporary directory name more explicit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,11 @@
 	* DESCRIPTION (Version, Date): Release 1.1.57-1 providing new Census
 	release X13-ARIMA-SEATS 1.1.57
 
+2021-04-05  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/checkX13binary.R (checkX13binary): Use explicit naming pattern
+	for temporary directory
+
 2021-03-30  Dirk Eddelbuettel  <edd@debian.org>
 
 	* R/checkX13binary.R: Use on.exit() for cleanup of tdir, reindented

--- a/R/checkX13binary.R
+++ b/R/checkX13binary.R
@@ -21,7 +21,7 @@ checkX13binary <- function(fail.unsupported = FALSE, verbose = TRUE) {
             stop("X-13 binary file not found")
         }
 
-        dir.create(tdir <- tempfile())
+        dir.create(tdir <- tempfile(pattern="x13binary__", fileext="__dir"))
         on.exit(unlink(tdir, recursive=TRUE, force=TRUE))
         file.copy(system.file("testdata", "Testairline.spc", package="x13binary"), tdir)
         if (.Platform$OS.type == "windows") {


### PR DESCRIPTION
This is a commit I had still lingering around from April when we tried to sort the 'random' failures out. I stashed it away yesterday but we may as well put it in -- it will make "our" temporary directories (much) more explicit giving us some idea where leftovers may be coming from.  