### PR TITLE
Simpler configure for SunOS

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^inst/bin/x13as*
 .*\.tar\.gz$
 ^\.github
+^inst/tools*

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-08-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* configure: Use simpler if statement to accomodate SunOS
+
+	* DESCRIPTION (Date, Version): Roll minor version
+
 2021-08-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 1.1.57-1

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-08-05  Dirk Eddelbuettel  <edd@debian.org>
+
+	* configure: Expanded message when no matching binary found
+	* inst/tools/build.sh: Add (failed) SunOS build attempt to repo
+	* .Rbuildignore: Add build script to exclude from installed package
+
 2021-08-04  Dirk Eddelbuettel  <edd@debian.org>
 
 	* configure: Use simpler if statement to accomodate SunOS

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: x13binary
 Type: Package
 Title: Provide the 'x13ashtml' Seasonal Adjustment Binary
-Version: 1.1.57-1
-Date: 2021-08-01
+Version: 1.1.57-1.1
+Date: 2021-08-04
 Author: Dirk Eddelbuettel and Christoph Sax
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: The US Census Bureau provides a seasonal adjustment program now

--- a/configure
+++ b/configure
@@ -23,7 +23,7 @@
 set -e
 
 ## Check that we are on Unix
-if ! [ -x `command -v uname` ]; then
+if [ x`command -v uname` = x ]; then
     echo "You do not have 'uname' so this is unlikely to be a Unix system. Exiting."
     exit 1
 fi

--- a/configure
+++ b/configure
@@ -57,10 +57,12 @@ else
     platform=${sysname}
     echo "Unusual platform: ${sysname}"
     echo ""
-    echo "For this platform and release, there are currently no binaries of X-13ARIMA-SEATS available."
-    echo "If you have binaries or building scripts, you are invited to contribute to the project."
+    echo "For this platform and release, there are currently no binaries of X-13ARIMA-SEATS available. If"
+    echo "you have binaries or building scripts, you are invited to contribute to the project."
     echo ""
-    echo "Visit: https://github.com/x13org/x13prebuilt"
+    echo "Visit https://github.com/x13org/x13prebuilt for the repository of pre-made binaries, and see eg"
+    echo "https://github.com/x13org/x13binary/blob/master/inst/tools/build.sh for an earlier attempt."
+    echo ""
     exit 3
 fi
 

--- a/inst/tools/build.sh
+++ b/inst/tools/build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# (Minimal, SunOS etc compatible) Build script for x13asHTML
+#
+# Copyright (C) 2015 - 2021  Dirk Eddelbuettel
+#
+# Released under GPL (>= 2)
+
+set -e
+set -u
+
+srctgz="https://www2.census.gov/software/x-13arima-seats/x13as/unix-linux/program-archives/x13as_htmlsrc-v1-1-b57.tar.gz"
+file=`basename ${srctgz}`
+echo "${file}"
+
+cwd=`pwd`
+td=`mktemp -d -p /tmp x13dirXXXXXX`
+cd ${td}
+wget ${srctgz}
+ls -l ${file}
+gunzip -v ${file}
+tarfile=`basename ${file} .gz`
+ls -l ${tarfile}
+tar xvf ${tarfile}
+#ls
+#make -f makefile.gf
+#for f in *.f; do
+#    gfortran -c -O1 ${f}
+#done
+#rm -f getarg.o gettim.o setarg.o
+#gfortran -static -o x13asHTML *.o -s -lm -lc
+gmake -f makefile.gf x13asHTMLsv11b57
+echo ""
+echo "Done in build directory ${td}"
+ls -l x13asHTMLsv11b57
+cd ${cwd}
+mv -v ${td}/x13asHTMLsv11b57 ../bin/x13ashtml
+rm -rf ${td}


### PR DESCRIPTION
This corrects the thinko in configure leading it to not fail over 'too advanced' syntax but properly error out when SunOS is recognised (as per a RHub run):

```
* installing *source* package â€˜x13binaryâ€™ ...
** using non-staged installation via StagedInstall field
'getOption("repos")' replaces Bioconductor standard repositories, see
'?repositories' for details

replacement repositories:
    CRAN: https://cloud.r-project.org

Unusual platform: SunOS

For this platform and release, there are currently no binaries of X-13ARIMA-SEATS available.
If you have binaries or building scripts, you are invited to contribute to the project.

Visit: https://github.com/x13org/x13prebuilt
ERROR: configuration failed for package â€˜x13binaryâ€™
* removing â€˜/export/home/Xns5A8O/R/x13binaryâ€™
```

(We can remove the line noise about Biconductor which is local to RHub.)   

It still fails, but it now fails with the intended message: No SunOS for you.  Until we find a volunteer to spin up the SunOS VM to build a binary for 1.1.57 in x13prebuilt, that is....