### PR TITLE
Add cleanup, simplify configure*, roll version back to dev release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /inst/bin/x13ashtml*
 /inst/lib/*
-/inst/*
 /tools/x13as_html/x13as_html
+.DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: x13binary
 Type: Package
 Title: Provide the 'x13ashtml' Seasonal Adjustment Binary
-Version: 1.1.60
+Version: 1.1.59.1
 Author: Dirk Eddelbuettel and Christoph Sax
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: The US Census Bureau provides a seasonal adjustment program now
@@ -15,4 +15,4 @@ URL: https://github.com/x13org/x13binary
 BugReports: https://github.com/x13org/x13binary/issues/
 RoxygenNote: 7.1.1
 Encoding: UTF-8
-SystemRequirements: Fortran binaries in `tools` are compiled via `configure`.
+SystemRequirements: Fortran sources included in `tools/x13as_html` are compiled via `configure`.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,12 @@ Package: x13binary
 Type: Package
 Title: Provide the 'x13ashtml' Seasonal Adjustment Binary
 Version: 1.1.59.1
-Author: Dirk Eddelbuettel and Christoph Sax
-Maintainer: Dirk Eddelbuettel <edd@debian.org>
+Authors@R: c(
+    person("Dirk", "Eddelbuettel", email = "edd@debian.org", role = ("aut", "cre"), comment = c(ORCID = "0000-0001-6419-907X")),
+    person("Christoph", "Sax", role = "aut", comment = c(ORCID = "0000-0002-7192-7044")),
+    person("Kirill", "Müller", role = "ctb", comment = c(ORCID = "0000-0002-1416-3412")),
+    person("Michael", "Antonov", role = "ctb")
+)
 Description: The US Census Bureau provides a seasonal adjustment program now
  called 'X-13ARIMA-SEATS' building on both earlier programs called X-11 and
  X-12 as well as the SEATS program by the Bank of Spain. The US Census Bureau

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,11 +3,11 @@ Type: Package
 Title: Provide the 'x13ashtml' Seasonal Adjustment Binary
 Version: 1.1.59.1
 Authors@R: c(
-    person("Dirk", "Eddelbuettel", email = "edd@debian.org", role = ("aut", "cre"), comment = c(ORCID = "0000-0001-6419-907X")),
+    person("Dirk", "Eddelbuettel", email = "edd@debian.org", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-6419-907X")),
     person("Christoph", "Sax", role = "aut", comment = c(ORCID = "0000-0002-7192-7044")),
     person("Kirill", "Müller", role = "ctb", comment = c(ORCID = "0000-0002-1416-3412")),
     person("Michael", "Antonov", role = "ctb")
-)
+    )
 Description: The US Census Bureau provides a seasonal adjustment program now
  called 'X-13ARIMA-SEATS' building on both earlier programs called X-11 and
  X-12 as well as the SEATS program by the Bank of Spain. The US Census Bureau

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,12 @@
-The x13binary source package contains only code that is copyright by Dirk
-Eddelbuettel and Christoph Sax, and released under the terms of the GNU
-General Public License, Version 2 or later ("GPL (>= 2)".
+The X-13ARIMA-SEATS Fortran source code is provided by the U.S. Census Bureau and is included in the source package at `tools/x13as_html`.
+The x13binary package uses these sources and builds an install-ready binary
+package of x13binary. The X-13ARIMA-SEATS manual at
 
-Using these sources and building an install-ready binary package of x13binary
-then adds the corresponding binary of x13ashtml, the X-13ARIMA-SEATS program
-by the US Census Bureau.  Its website at 
-                https://www.census.gov/srd/www/x13as/
-carries thec following statement
+  https://www2.census.gov/software/x-13arima-seats/x13as/windows/documentation/docx13as.pdf
 
-  License Information and Disclaimer (March 1, 2016):
+carries thec following statement:
+
+  License Information and Disclaimer (June 12, 2023):
 
   This Software was created by U.S. Government employees and therefore is not
   subject to copyright in the United States (17 U.S.C. §105). The United
@@ -45,3 +43,8 @@ carries thec following statement
   User agrees to make a good faith effort to use the Software in a way that does
   not cause damage, harm, or embarrassment to the United States/Commerce. The
   United States/Commerce expressly reserve all rights and remedies.
+
+The remaining code is copyright by the authors of the R package, and released
+under the terms of the GNU General Public License, Version 2 or later
+("GPL (>= 2)".
+

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@
 
 ### About
 
-This package provides an installer for [R](https://www.r-project.org) to
-access prebuilt binaries of [X-13ARIMA-SEATS](https://www.census.gov/data/software/x13as.X-13ARIMA-SEATS.html) from the sibbling
-repository [x13prebuilt](https://github.com/x13org/x13prebuilt). This allows
-for fully automated installation of a
+This package provides binaries of [X-13ARIMA-SEATS](https://www.census.gov/data/software/x13as.X-13ARIMA-SEATS.html) and makes them available in [R](https://www.r-project.org). It builds them from the Fortran code provided by the US Census Bureau.
+This allows for fully automated installation of a
 [X-13ARIMA-SEATS](https://www.census.gov/data/software/x13as.X-13ARIMA-SEATS.html) binary simply by
 adding `Depends: x13binary` to your R package.
 
@@ -26,23 +24,55 @@ install.packages("x13binary")
 
 ### Status
 
-This package as well as the corresponding
-[x13prebuilt](https://github.com/x13org/x13prebuilt) repository are
-operational for Windows, OS X (Darwin) and Linux (via using statically linked
-binaries).
-
 The current version of [x13binary](https://github.com/x13org/x13binary) uses
-**version 1.1, build 57** of of X-13, as can be verified by:
+**version 1.1, build 60** of of X-13, as can be verified by:
 
 ```
 seasonal::udg(seasonal::seas(AirPassengers), c("version", "build"))
 ```
 
 
-### Author 
+### License Information and Disclaimer
 
-Dirk Eddelbuettel and Christoph Sax
+As stated in the manual of
+[X-13ARIMA-SEATS](https://www2.census.gov/software/x-13arima-seats/x13as/windows/documentation/docx13as.pdf)
+(June 12, 2023):
 
-### License
+> This Software was created by U.S. Government employees and therefore is not
+> subject to copyright in the United States (17 U.S.C. §105). The United
+> States/U.S. Department of Commerce (“Commerce”) reserve all rights to seek and
+> obtain copyright protection in countries other than the United States. The
+> United States/Commerce hereby grant to User a royalty-free, nonexclusive
+> license to use, copy, and create derivative works of the Software outside of
+> the United States.
 
-GPL (>= 2)
+> The Software is provided to the User and those who may take by, through or
+> under it, “as is,” without any warranty (whether express or implied) or
+> representation whatsoever, including but not limited to any warranty of
+> merchantability. The Software is taken hereunder without any right to support
+> or to any improvements, extensions, or modifications, except as may be agreed
+> to separately, in writing, by Commerce.
+
+> User, on behalf of itself and all others who take by, through or under it,
+> hereby and forever waives, releases, and discharges the United States/Commerce
+> and all its instrumentalities from any and all liabilities and obligations in
+> connection with the use, application, sale or conveyance of the Software. User
+> shall indemnify and hold harmless the United States/Commerce and its
+> instrumentalities from all claims, liabilities, demands, damages, expenses,
+> and losses arising from or in connection with User's use, application, sale or
+> conveyance of the Software, including those who take by, through or under User
+> whether or not User was directly involved. This provision will survive
+> termination of this Agreement and will include any and all claims or
+> liabilities arising under intellectual property rights, such as patents,
+> copyrights, trademarks, and trade secrets. If User of software is an Executive
+> Agency of the United States, this clause is not applicable.
+
+> The construction, validity, performance, and effect of this Agreement for all
+> purposes will be governed by Federal law of the United States.
+
+> User agrees to make a good faith effort to use the Software in a way that does
+> not cause damage, harm, or embarrassment to the United States/Commerce. The
+> United States/Commerce expressly reserve all rights and remedies.
+
+
+The R Package was created by Dirk Eddelbuettel, Christoph Sax, Kirill Müller and Michael Antonov and is licensed under GPL (>= 2) and LICE

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ As stated in the manual of
 > United States/Commerce expressly reserve all rights and remedies.
 
 
-The R Package was created by Dirk Eddelbuettel, Christoph Sax, Kirill Müller and Michael Antonov and is licensed under GPL (>= 2) and LICE
+The R Package was created by Dirk Eddelbuettel, Christoph Sax, Kirill Müller and Michael Antonov and is licensed under GPL (>= 2).

--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+rm -f tools/x13as_html/*.o tools/x13as_html/x13as_html tools/x13as_html/x13as_html.exe \
+   inst/bin/x13as_html inst/bin/x13as_html.exe

--- a/configure
+++ b/configure
@@ -22,12 +22,8 @@
 
 set -e
 
-cd "$(dirname "$0")"
-root="$(pwd)"
-
-cd ./tools/x13as_html
+cd tools/x13as_html
 make -f makefile.gf
-
-cp x13as_html $root/inst/bin/x13ashtml
+cp x13as_html ../../inst/bin/x13ashtml
 
 exit 0

--- a/configure.win
+++ b/configure.win
@@ -1,12 +1,8 @@
 #!/bin/sh
 set -e
 
-cd "$(dirname "$0")"
-root="$(pwd)"
-
-cd ./tools/x13as_html
+cd tools/x13as_html
 make -f makefile.gf
-
-cp x13as_html.exe $root/inst/bin/x13ashtml.exe
+cp x13as_html.exe ../../inst/bin/x13ashtml.exe
 
 exit 0

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -1,0 +1,9 @@
+X-13ARIMA-SEATS Seasonal Adjustment Program
+Developed by the U.S. Census Bureau
+
+This R package uses Fortran code from the X-13ARIMA-SEATS Seasonal Adjustment Program.
+The version used is Version 1.1, Build 60, last updated in July 10, 2023, available at: https://www.census.gov/data/software/x13as.X-13ARIMA-SEATS.html
+
+U.S. Census Bureau
+
+The R Package was created by Dirk Eddelbuettel, Christoph Sax, Kirill Müller and Michael Antonov.

--- a/inst/COPYRIGHT
+++ b/inst/COPYRIGHT
@@ -1,9 +1,9 @@
 
 Overall license:
 ================
-The actual X-13ARIMA-SEATS binary is provided under these terms
+The actual X-13ARIMA-SEATS Fortran source code is provided under these terms
 
-  License Information and Disclaimer (March 1, 2016):
+  License Information and Disclaimer (June 12, 2023):
 
   This Software was created by U.S. Government employees and therefore is not
   subject to copyright in the United States (17 U.S.C. §105). The United
@@ -49,10 +49,10 @@ Details:
 ========
 
 Files: *
-Copyright: 2015 - 2016  Dirk Eddelbuettel and Christoph Sax
+Copyright: 2015 - 2023  R package authors
 License: GPL (>= 2)
 
-Files: inst/bin/x13*:
+Files: tools/x13as_html/*:
 Copyright: This Software was created by U.S. Government employees and therefore 
   is not subject to copyright in the United States (17 U.S.C. §105). The United
   States/U.S. Department of Commerce (“Commerce”) reserve all rights to seek and
@@ -60,4 +60,4 @@ Copyright: This Software was created by U.S. Government employees and therefore
   United States/Commerce hereby grant to User a royalty-free, nonexclusive
   license to use, copy, and create derivative works of the Software outside of
   the United States.
-License: See above, and https://www.census.gov/srd/www/x13as/
+License: See above, and https://www2.census.gov/software/x-13arima-seats/x13as/windows/documentation/docx13as.pdf


### PR DESCRIPTION
The configure scripts can be simplified; the script is guaranteed to be executed in the repo root (or top of unpacked tarball).  I also rolled the version back as 1.1.60 should be reserved for 'when we are ready to release'.

See e.g. #69 -- what else is left to do in terms of our documentation and hence change in authorship / ownership?  