### PR TITLE
Support all platforms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,6 @@ License: file LICENSE
 Copyright: file inst/COPYRIGHT
 URL: https://github.com/x13org/x13binary
 BugReports: https://github.com/x13org/x13binary/issues/
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 Encoding: UTF-8
 SystemRequirements: Fortran sources included in `tools/x13as_html` are compiled via `configure`.

--- a/R/supportedPlatform.R
+++ b/R/supportedPlatform.R
@@ -1,6 +1,6 @@
 #' Test Platform Support
 #' 
-#' Returns \code{TRUE} is the platform is supported, \code{FALSE} otherwise.
+#' Always returns \code{TRUE}.
 #'  
 #' @examples
 #' supportedPlatform()
@@ -8,43 +8,5 @@
 #' @export
 #' @import utils
 supportedPlatform <- function(){
-
-  z <- FALSE  # in case we missed something
-
-  # Windows
-  if (.Platform$OS.type == "windows"){
-    z <- TRUE
-  }
-
-  # Linux
-  if (Sys.info()["sysname"] %in% c("Linux")){
-    z <- TRUE
-  }
-
-  # macOS
-  if (Sys.info()["sysname"] %in% c("Darwin")){
-    # Darwin Version numbers for macOS/OS-X Versions 
-    # https://en.wikipedia.org/wiki/Darwin_(operating_system)
-    #     10  OS X Snow Leopard
-    # 11.0.0  OS X Lion
-    # 12.0.0  OS X Mountain Lion
-    # 12.6.0  
-    # 13.0.0  OS X Mavericks
-    # 13.4.0  
-    # 14.0.0  OS X Yosemite
-    # 14.5.0  
-    # 15.0.0  OS X El Capitan
-    # 15.2.0  
-
-    # needs to be at least Lion (this has been tested in early 2016)
-    z <- compareVersion(Sys.info()["release"], "11.0.0") >= 0
-  }
-
-  # Other Unix (eg Solaris)
-  if ((.Platform$OS.type == "unix") && 
-      !(Sys.info()["sysname"] %in% c("Darwin", "Linux"))){
-    z <- FALSE
-  }
-
-  z
+  TRUE
 }

--- a/man/supportedPlatform.Rd
+++ b/man/supportedPlatform.Rd
@@ -7,7 +7,7 @@
 supportedPlatform()
 }
 \description{
-Returns \code{TRUE} is the platform is supported, \code{FALSE} otherwise.
+Always returns \code{TRUE}.
 }
 \examples{
 supportedPlatform()


### PR DESCRIPTION
As discussed in #76, we now support all platforms.

Whether X13 actually builds and runs successfully will continue to be tested by `checkX13binary()`.
