### PR TITLE
Release 1.1.60

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,46 @@
+2024-01-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Release 1.1.60
+
+	* src/install.libs.R: Use install_name_tool on macOS to update
+	dynamoc library registration of quadmath library for binary
+
+2024-01-21  Christoph Sax  <christoph.sax@gmail.com>
+
+	* R/supportedPlatform.R: Simplify check
+	* man/supportedPlatform.Rd: Documentation
+
+2024-01-20  Jeroen Ooms  <jeroenooms@gmail.com>
+
+	* src/install.libs.R: Use install_name_tool on macOS to update
+	dynamoc library registration of Fortran library for binary
+
+2024-01-18  Jeroen Ooms  <jeroenooms@gmail.com>
+
+	* configure: Use the CRAN-supplied Fortran compiler on macOS
+	* configure.win: Idem
+	* src/Makefile: Idem
+	* src/Makefile.win: Idem
+	* src/install.libs.R: Idem
+	* tools/x13as_html/makefile.gd: Idem
+
+2024-01-16  Christoph Sax  <christoph.sax@gmail.com>
+
+	* tests/simpleTest.R: Tweak
+	* DESCRIPTION: Roll micro version
+
+2024-01-10  Christoph Sax  <christoph.sax@gmail.com>
+
+	* various: Miscellaneous package meta data updates (PR 70)
+
+2023-12-12  Christoph Sax  <christoph.sax@gmail.com>
+
+	* DESCRIPTION: Update Description
+	* README.md: Idem
+
+	* various: Merge extended work by Michael and Kirill taking first
+	stab at building from Fortran source (PR #67)
+
 2023-09-07  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 1.1.57-4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,8 @@
 Package: x13binary
 Type: Package
 Title: Provide the 'x13ashtml' Seasonal Adjustment Binary
-Version: 1.1.59.2
+Version: 1.1.60
+Date: 2024-01-22
 Authors@R: c(
     person("Dirk", "Eddelbuettel", email = "edd@debian.org", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-6419-907X")),
     person("Christoph", "Sax", role = "aut", comment = c(ORCID = "0000-0002-7192-7044")),

--- a/tests/simpleTest.R
+++ b/tests/simpleTest.R
@@ -1,6 +1,3 @@
-x13binary::checkX13binary()
-
 
 library(x13binary)
-
 checkX13binary()

--- a/tests/simpleTest.Rout.save
+++ b/tests/simpleTest.Rout.save
@@ -1,0 +1,25 @@
+
+R Under development (unstable) (2024-01-08 r85790) -- "Unsuffered Consequences"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
+
+R is free software and comes with ABSOLUTELY NO WARRANTY.
+You are welcome to redistribute it under certain conditions.
+Type 'license()' or 'licence()' for distribution details.
+
+R is a collaborative project with many contributors.
+Type 'contributors()' for more information and
+'citation()' on how to cite R or R packages in publications.
+
+Type 'demo()' for some demos, 'help()' for on-line help, or
+'help.start()' for an HTML browser interface to help.
+Type 'q()' to quit R.
+
+> 
+> library(x13binary)
+> checkX13binary()
+x13binary is working properly
+> 
+> proc.time()
+   user  system elapsed 
+  0.410   0.028   0.431 


### PR DESCRIPTION
This PR prepares 1.1.60.  

I made a final change simplifying the one tests (which we only need to run once) but also adding a reference output of 'success' so that R will fail a check if this fails to match.  It uses the old-old trick of storing the test output as a file ending in `.Rout.save`.

And I made a quick attempt at backfilling the ChangeLog.  Improvements to that are of course welcome too.

I won't upload until a get a 'thumbs up' approval, and I suggest to not merge until this is on CRAN allowing for any last minute change the CRAN team may require.  That pattern of 'holding' the new release PR has worked well for me in many other package contexts.