### PR TITLE
Replace GNU extension fdate() with standard date_and_time()

### DIFF
--- a/tools/x13as_html/aaamain.f
+++ b/tools/x13as_html/aaamain.f
@@ -86,7 +86,7 @@ C-----------------------------------------------------------------------
       Ierhdr=NOTSET
       Crvend=CNOTST
       dattim='                        '
-      CALL fdate(dattim)
+      CALL date_and_time(dattim)
       dattim=cvdttm(dattim)
 cunix
       CHREOF=char(4)
@@ -245,7 +245,7 @@ C-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
        ELSE IF(.not.lchkin)THEN
         dattim='                        '
-        CALL fdate(dattim)
+        CALL date_and_time(dattim)
         dattim=cvdttm(dattim)
         WRITE(STDOUT,1020)' Execution complete for '//Infile(1:n1)//
      &                    '.spc at '//dattim

--- a/tools/x13as_html/agr3.f
+++ b/tools/x13as_html/agr3.f
@@ -76,7 +76,7 @@ c      Kpage=0
        CALL genSkip(LCMPAH)
        WRITE(Mt1,1010)PRGNAM,Cbr,Cbr,VERNUM,BUILD
        WRITE(Mt1,1020)Title,Cbr,Serno(1:Nser)
-       CALL fdate(dattim)
+       CALL date_and_time(dattim)
        dattim=cvdttm(dattim)
        CALL mkPOneLine(Mt1,'@',dattim)
        WRITE(Mt1,1040)'<p>',Begspn(MO),Begspn(YR),Lstmo,Lstyr 

--- a/tools/x13as_html/agr3s.f
+++ b/tools/x13as_html/agr3s.f
@@ -68,7 +68,7 @@ c     ------------------------------------------------------------------
        CALL genSkip(LCMPAH)
        WRITE(Mt1,1010)PRGNAM,Cbr,Cbr,VERNUM,BUILD
        WRITE(Mt1,1020)Title,Cbr,Serno(1:Nser)
-       CALL fdate(dattim)
+       CALL date_and_time(dattim)
        dattim=cvdttm(dattim)
        CALL mkPOneLine(Mt1,'@',dattim)
        WRITE(Mt1,1040)'<p>',Begspn(MO),Begspn(YR),Lstmo,Lstyr 


### PR DESCRIPTION
This makes the build work with `flang-new-17` on Debian which is what CRAN uses.

[FDATE](https://gcc.gnu.org/onlinedocs/gfortran/FDATE.html) is a GNU extension that is currently not implemented in flang. The [DATE_AND_TIME](https://gcc.gnu.org/onlinedocs/gfortran/DATE_005fAND_005fTIME.html) function is standard f90. 

I am not sure if there are any side effects. Both functions seem to print the current date to a string, but perhaps they use another format. I am not sure how important that is.

Perhaps this workaround can be reverted when CRAN has upgraded to LLVM-18.