### PR TITLE
Suppress stderr when checking to avoid flang-new nag

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-06-23  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/checkX13binary.R (checkX13binary): Ignore stderr to avoid nag
+	seen with builds from flang-new (with thanks to Kurt Hornik)
+
 2024-01-21  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 1.1.60

--- a/R/checkX13binary.R
+++ b/R/checkX13binary.R
@@ -44,7 +44,8 @@ checkX13binary <- function(fail.unsupported = FALSE, verbose = TRUE) {
                      paste(strwrap(sout, indent = 2, exdent = 2), collapse = "\n"), "\n\n")
             }
         } else {
-            sout <- system(paste(x13.bin, file.path(tdir, "Testairline")), intern = TRUE)
+            sout <- system(paste(x13.bin, file.path(tdir, "Testairline")),
+                           intern = TRUE, ignore.stderr = TRUE)
             if (isTRUE(attr(sout,"status") != 0)) {
                 stop("When running\n\n  ", x13.bin,
                      "\n\nthe system returned the following message:\n\n",


### PR DESCRIPTION
As suggested by @kurthornik (via email), we now ignore stderr when checking if the located binary can operate on the airlines test file.  

Apparently things do change even in the Fortran world and the compiler from the clang family makes noise on stderr even if no other Fortran compiler before it did.  Suppressing the noise avoids a nag at CRAN from package relying on x13binary via seaonsal.