### PR TITLE
Release 1.1.16.1 correcting a format string warning from gfortran-15

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-08-19  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Release 1.1.61.1
+
+	* tools/x13as_html/htmlout.f (tablePeakHtm): Add a missing comma
+	as detected by recent gfortran-15 version
+
 2024-07-21  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Switch some URLs from http to https

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: x13binary
 Type: Package
 Title: Provide the 'x13ashtml' Seasonal Adjustment Binary
-Version: 1.1.61
-Date: 2024-06-23
+Version: 1.1.61.1
+Date: 2025-08-19
 Authors@R: c(
     person("Dirk", "Eddelbuettel", email = "edd@debian.org", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-6419-907X")),
     person("Christoph", "Sax", role = "aut", comment = c(ORCID = "0000-0002-7192-7044")),
@@ -21,4 +21,4 @@ URL: https://github.com/x13org/x13binary
 BugReports: https://github.com/x13org/x13binary/issues/
 RoxygenNote: 7.2.3
 Encoding: UTF-8
-SystemRequirements: Fortran sources included in `tools/x13as_html` are compiled via `configure`.
+SystemRequirements: Fortran sources included in `tools/x13as_html` require a Fortran compiler

--- a/tools/x13as_html/htmlout.f
+++ b/tools/x13as_html/htmlout.f
@@ -3107,7 +3107,7 @@ c -------------------
 c
       if (isTable.eq.0) then
         write (u,'(''<table>'')')
-        write (u,'("<caption>Spectral Diagnostics ",A
+        write (u,'("<caption>Spectral Diagnostics ",A,
      $                       "</caption>")') CompName
       else
        call WriteDoctype(u,1)


### PR DESCRIPTION
Closes #87

A one-char fix, wrapped in a new micro release 1.1.61.1 to address the warning from a (very current) CRAN machine with a (new enough) `gfortran-15` binary.