### PR TITLE
As r-ci installs Fortran on macOS too we do not a special block

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,23 +26,6 @@ jobs:
       - name: Setup
         uses: eddelbuettel/github-actions/r-ci@master
 
-      - name: Install CRAN fortran
-        if: runner.os == 'macos'
-        run: |
-          curl --retry 3 -fsSLO https://github.com/R-macos/gcc-12-branch/releases/download/12.2-darwin-r0.1/gfortran-12.2-universal.pkg
-          sudo installer -pkg "gfortran-12.2-universal.pkg" -target /
-          rm -f gfortran-12.2-universal.pkg
-          echo "/opt/gfortran/bin" >> $GITHUB_PATH
-
-      - uses: fortran-lang/setup-fortran@v1
-        if: runner.os != 'macos'
-        id: setup-fortran
-
-      - run: ${{ env.FC }} --version
-        if: runner.os != 'macos'
-        env:
-          FC: ${{ steps.setup-fortran.outputs.fc }}
-
       - name: Dependencies
         run: ./run.sh install_deps
 
@@ -50,7 +33,6 @@ jobs:
         run: ./run.sh run_tests
 
       - name: Dump logs
-        if: always()
         run: ./run.sh dump_logs
 
       #- name: Coverage


### PR DESCRIPTION
Minor cleanup in CI script as the once-added snippet is no longer needed.  

Nothing user-facing changed, nor did the code.